### PR TITLE
Update for Elm 0.17

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -8,8 +8,8 @@
     ],
     "exposed-modules": [ "Form.Infix" ],
     "dependencies": {
-        "elm-lang/core": "3.0.0 <= v < 4.0.0",
-        "etaque/elm-simple-form": "2.0.0 <= v < 3.0.0"
+        "elm-lang/core": "4.0.0 <= v < 5.0.0",
+        "etaque/elm-simple-form": "3.0.0 <= v < 6.0.0"
     },
-    "elm-version": "0.16.0 <= v < 0.17.0"
+    "elm-version": "0.17.0 <= v < 0.18.0"
 }

--- a/src/Form/Infix.elm
+++ b/src/Form/Infix.elm
@@ -1,4 +1,4 @@
-module Form.Infix ((:=), (?=), (|:)) where
+module Form.Infix exposing ((:=), (?=), (|:))
 
 {-| Form validation infix operators.
 


### PR DESCRIPTION
This is tested against the latest elm-simple-form (5.0.1) but makes the assumption it'll work with earlier 0.17-compatible versions.
